### PR TITLE
Fix stacked bar chart

### DIFF
--- a/lib/rails_charts/stacked_bar_chart.rb
+++ b/lib/rails_charts/stacked_bar_chart.rb
@@ -4,7 +4,7 @@ module RailsCharts
     def defaults
       super.deep_merge({
         series: {
-          stack: {}        
+          stack: 'stack',
         },
       })
     end


### PR DESCRIPTION
Allows stacked bar chart to stack as per ECharts instead of superimposing.

Consider
```
<%= stacked_bar_chart [
                                              { name: 'Pending', data: {'Jan 1' => 5, 'Jan 2' => 6, 'Jan 3' => 10}},
                                              { name: 'Done', data: {'Jan 1' => 6, 'Jan 2' => 4, 'Jan 3' => 1}}
                              ],
                              {
                                options: {
                                  title: {
                                    text: "Popular vs Unpopular"
                                  },
                                },
                                class: 'box',
                                vertical: true
                              } %>
```
yields
![image](https://github.com/railsjazz/rails_charts/assets/57301442/2956701f-9914-4a95-b955-b8cc434c3c5b)

With this change, the same code yields
<img width="861" alt="image" src="https://github.com/railsjazz/rails_charts/assets/57301442/41b0a2ab-a6c1-4e9a-b96e-2ec866d94854">

Not sure if it's meant to be extensible. I've tried to add `stack: 'stack'` in multiple places with the existing code, but it's unclear how to fix it. If this already exists properly, adding the explanation to the docs would be great