### PR TITLE
Add options to as_json

### DIFF
--- a/lib/rails_charts/javascript.rb
+++ b/lib/rails_charts/javascript.rb
@@ -6,7 +6,7 @@ module RailsCharts
       @code = code
     end
 
-    def as_json(attrs)
+    def as_json(options = nil)
       "RAILS_CHART_JS:#{Base64.strict_encode64(code)}:RAILS_CHART_JS_END"
     end
   end


### PR DESCRIPTION
Getting the following error when rendering a chart and using javascript function:
```
ActionView::Template::Error (wrong number of arguments (given 0, expected 1)):
    22:     "2023-02-06"=>-105.5374262253
    23:   } %>
    24:
    25:   <%= line_chart(@data, options: {
    26:     tooltip: {
    27:       valueFormatter: RailsCharts.js(
    28:         "(value) => '$ ' + value.toFixed(2)"
```
Code to reproduce:
```erb
  <% @data = {
    "2023-01-29"=>-4.92395977584,
    "2023-01-30"=>-14.167966603290001,
    "2023-01-31"=>-43.507681167049995,
    "2023-02-01"=>-68.84430564245,
    "2023-02-02"=>-87.68481832146,
    "2023-02-06"=>-105.5374262253
  } %>

  <%= line_chart(@data, options: {
    tooltip: {
      valueFormatter: RailsCharts.js(
        "(value) => '$ ' + value.toFixed(2)"
      )
    }
  }) %>
```
I'm using ruby 3.2.2 and rails 7.1.2