### PR TITLE
Force UTF-8 encoding when parsing javascript code string

### DIFF
--- a/lib/rails_charts/base_chart.rb
+++ b/lib/rails_charts/base_chart.rb
@@ -83,7 +83,7 @@ module RailsCharts
 
     def option
       str = build_options.to_json
-      str.gsub!(CHART_JS_PATTERN) { Base64.decode64 $1 }
+      str.gsub!(CHART_JS_PATTERN) { Base64.decode64($1).force_encoding(Encoding::UTF_8) }
       str
     end
 

--- a/test/dummy/app/views/home/_bar_chart.html.erb
+++ b/test/dummy/app/views/home/_bar_chart.html.erb
@@ -9,7 +9,7 @@
       }
     },
     tooltip: {
-      valueFormatter: RailsCharts.js("(value) => '$' + value")
+      valueFormatter: RailsCharts.js("(value) => value + 'долларів'")
     }
   }
 %>
@@ -19,7 +19,7 @@
   class: 'box',
   theme: 'sakura',
   options: {
-    series: { 
+    series: {
       barWidth: '50%'
     },
     tooltip: {


### PR DESCRIPTION
There's an error that appears
```
incompatible character encodings: ASCII-8BIT and UTF-8
```
if the `Rails.js("(param) => ...")` code string contains any non-ASCII-8BIT characters.

For reason I was unable to comprehend that this does not happen in the console, but only in the context of ActionView template.