### PR TITLE
Register rails_chart_function in Turbo Frame event

### DIFF
--- a/lib/rails_charts/base_chart.rb
+++ b/lib/rails_charts/base_chart.rb
@@ -72,8 +72,12 @@ module RailsCharts
 
             window.addEventListener('load', init_#{chart_id});
             window.addEventListener('turbo:load', init_#{chart_id});
-            window.addEventListener('turbolinks:load', init_#{chart_id});
 
+            window.addEventListener('turbolinks:load', init_#{chart_id});
+            window.addEventListener('turbo:frame-render', init_#{chart_id});
+            window.addEventListener('turbo:frame-load', ()=> {
+                window.removeEventListener('turbo:frame-render', init_#{chart_id});
+            });
             document.addEventListener("turbolinks:before-render", destroy_#{chart_id});
             document.addEventListener("turbo:before-render", destroy_#{chart_id});
           </script>

--- a/lib/rails_charts/stacked_bar_chart.rb
+++ b/lib/rails_charts/stacked_bar_chart.rb
@@ -4,7 +4,7 @@ module RailsCharts
     def defaults
       super.deep_merge({
         series: {
-          stack: {}        
+          stack: 'stack',
         },
       })
     end


### PR DESCRIPTION
Hey,
thanks for your library. It's working really good for us.
We found that, in our case, we need the lazy load behavior since we are heavily relying in turbo frames.
I saw the comment in #17 and with this setup the rails_charts_ init function are de-registered so we can see that the function is, effectively, not triggered in the next turbo frame response.

I hope this would work for you.
