### PR TITLE
Fixes lookup for echarts in theme files

### DIFF
--- a/app/assets/javascripts/echarts/theme/azul.js
+++ b/app/assets/javascripts/echarts/theme/azul.js
@@ -31,7 +31,7 @@
         // Browser globals
         factory({}, root.echarts);
     }
-})(this, function(exports, echarts) {
+})(this || window, function(exports, echarts) {
     var log = function(msg) {
         if (typeof console !== 'undefined') {
             console && console.error && console.error(msg);

--- a/app/assets/javascripts/echarts/theme/bee-inspired.js
+++ b/app/assets/javascripts/echarts/theme/bee-inspired.js
@@ -31,7 +31,7 @@
         // Browser globals
         factory({}, root.echarts);
     }
-})(this, function(exports, echarts) {
+})(this || window, function(exports, echarts) {
     var log = function(msg) {
         if (typeof console !== 'undefined') {
             console && console.error && console.error(msg);

--- a/app/assets/javascripts/echarts/theme/blue.js
+++ b/app/assets/javascripts/echarts/theme/blue.js
@@ -31,7 +31,7 @@
         // Browser globals
         factory({}, root.echarts);
     }
-})(this, function(exports, echarts) {
+})(this || window, function(exports, echarts) {
     var log = function(msg) {
         if (typeof console !== 'undefined') {
             console && console.error && console.error(msg);

--- a/app/assets/javascripts/echarts/theme/caravan.js
+++ b/app/assets/javascripts/echarts/theme/caravan.js
@@ -31,7 +31,7 @@
         // Browser globals
         factory({}, root.echarts);
     }
-})(this, function(exports, echarts) {
+})(this || window, function(exports, echarts) {
     var log = function(msg) {
         if (typeof console !== 'undefined') {
             console && console.error && console.error(msg);

--- a/app/assets/javascripts/echarts/theme/carp.js
+++ b/app/assets/javascripts/echarts/theme/carp.js
@@ -31,7 +31,7 @@
         // Browser globals
         factory({}, root.echarts);
     }
-})(this, function(exports, echarts) {
+})(this || window, function(exports, echarts) {
     var log = function(msg) {
         if (typeof console !== 'undefined') {
             console && console.error && console.error(msg);

--- a/app/assets/javascripts/echarts/theme/cool.js
+++ b/app/assets/javascripts/echarts/theme/cool.js
@@ -31,7 +31,7 @@
         // Browser globals
         factory({}, root.echarts);
     }
-})(this, function(exports, echarts) {
+})(this || window, function(exports, echarts) {
     var log = function(msg) {
         if (typeof console !== 'undefined') {
             console && console.error && console.error(msg);

--- a/app/assets/javascripts/echarts/theme/dark-blue.js
+++ b/app/assets/javascripts/echarts/theme/dark-blue.js
@@ -31,7 +31,7 @@
         // Browser globals
         factory({}, root.echarts);
     }
-})(this, function(exports, echarts) {
+})(this || window, function(exports, echarts) {
     var log = function(msg) {
         if (typeof console !== 'undefined') {
             console && console.error && console.error(msg);

--- a/app/assets/javascripts/echarts/theme/dark-bold.js
+++ b/app/assets/javascripts/echarts/theme/dark-bold.js
@@ -31,7 +31,7 @@
         // Browser globals
         factory({}, root.echarts);
     }
-})(this, function(exports, echarts) {
+})(this || window, function(exports, echarts) {
     var log = function(msg) {
         if (typeof console !== 'undefined') {
             console && console.error && console.error(msg);

--- a/app/assets/javascripts/echarts/theme/dark-digerati.js
+++ b/app/assets/javascripts/echarts/theme/dark-digerati.js
@@ -31,7 +31,7 @@
         // Browser globals
         factory({}, root.echarts);
     }
-})(this, function(exports, echarts) {
+})(this || window, function(exports, echarts) {
     var log = function(msg) {
         if (typeof console !== 'undefined') {
             console && console.error && console.error(msg);

--- a/app/assets/javascripts/echarts/theme/dark-fresh-cut.js
+++ b/app/assets/javascripts/echarts/theme/dark-fresh-cut.js
@@ -31,7 +31,7 @@
         // Browser globals
         factory({}, root.echarts);
     }
-})(this, function(exports, echarts) {
+})(this || window, function(exports, echarts) {
     var log = function(msg) {
         if (typeof console !== 'undefined') {
             console && console.error && console.error(msg);

--- a/app/assets/javascripts/echarts/theme/dark-mushroom.js
+++ b/app/assets/javascripts/echarts/theme/dark-mushroom.js
@@ -31,7 +31,7 @@
         // Browser globals
         factory({}, root.echarts);
     }
-})(this, function(exports, echarts) {
+})(this || window, function(exports, echarts) {
     var log = function(msg) {
         if (typeof console !== 'undefined') {
             console && console.error && console.error(msg);

--- a/app/assets/javascripts/echarts/theme/dark.js
+++ b/app/assets/javascripts/echarts/theme/dark.js
@@ -31,7 +31,7 @@
         // Browser globals
         factory({}, root.echarts);
     }
-})(this, function(exports, echarts) {
+})(this || window, function(exports, echarts) {
     var log = function(msg) {
         if (typeof console !== 'undefined') {
             console && console.error && console.error(msg);

--- a/app/assets/javascripts/echarts/theme/eduardo.js
+++ b/app/assets/javascripts/echarts/theme/eduardo.js
@@ -31,7 +31,7 @@
         // Browser globals
         factory({}, root.echarts);
     }
-})(this, function(exports, echarts) {
+})(this || window, function(exports, echarts) {
     var log = function(msg) {
         if (typeof console !== 'undefined') {
             console && console.error && console.error(msg);

--- a/app/assets/javascripts/echarts/theme/forest.js
+++ b/app/assets/javascripts/echarts/theme/forest.js
@@ -31,7 +31,7 @@
         // Browser globals
         factory({}, root.echarts);
     }
-})(this, function(exports, echarts) {
+})(this || window, function(exports, echarts) {
     var log = function(msg) {
         if (typeof console !== 'undefined') {
             console && console.error && console.error(msg);

--- a/app/assets/javascripts/echarts/theme/fresh-cut.js
+++ b/app/assets/javascripts/echarts/theme/fresh-cut.js
@@ -31,7 +31,7 @@
         // Browser globals
         factory({}, root.echarts);
     }
-})(this, function(exports, echarts) {
+})(this || window, function(exports, echarts) {
     var log = function(msg) {
         if (typeof console !== 'undefined') {
             console && console.error && console.error(msg);

--- a/app/assets/javascripts/echarts/theme/fruit.js
+++ b/app/assets/javascripts/echarts/theme/fruit.js
@@ -31,7 +31,7 @@
         // Browser globals
         factory({}, root.echarts);
     }
-})(this, function(exports, echarts) {
+})(this || window, function(exports, echarts) {
     var log = function(msg) {
         if (typeof console !== 'undefined') {
             console && console.error && console.error(msg);

--- a/app/assets/javascripts/echarts/theme/gray.js
+++ b/app/assets/javascripts/echarts/theme/gray.js
@@ -31,7 +31,7 @@
         // Browser globals
         factory({}, root.echarts);
     }
-})(this, function(exports, echarts) {
+})(this || window, function(exports, echarts) {
     var log = function(msg) {
         if (typeof console !== 'undefined') {
             console && console.error && console.error(msg);

--- a/app/assets/javascripts/echarts/theme/green.js
+++ b/app/assets/javascripts/echarts/theme/green.js
@@ -31,7 +31,7 @@
         // Browser globals
         factory({}, root.echarts);
     }
-})(this, function(exports, echarts) {
+})(this || window, function(exports, echarts) {
     var log = function(msg) {
         if (typeof console !== 'undefined') {
             console && console.error && console.error(msg);

--- a/app/assets/javascripts/echarts/theme/helianthus.js
+++ b/app/assets/javascripts/echarts/theme/helianthus.js
@@ -31,7 +31,7 @@
         // Browser globals
         factory({}, root.echarts);
     }
-})(this, function(exports, echarts) {
+})(this || window, function(exports, echarts) {
     var log = function(msg) {
         if (typeof console !== 'undefined') {
             console && console.error && console.error(msg);

--- a/app/assets/javascripts/echarts/theme/infographic.js
+++ b/app/assets/javascripts/echarts/theme/infographic.js
@@ -31,7 +31,7 @@
         // Browser globals
         factory({}, root.echarts);
     }
-})(this, function(exports, echarts) {
+})(this || window, function(exports, echarts) {
     var log = function(msg) {
         if (typeof console !== 'undefined') {
             console && console.error && console.error(msg);

--- a/app/assets/javascripts/echarts/theme/inspired.js
+++ b/app/assets/javascripts/echarts/theme/inspired.js
@@ -31,7 +31,7 @@
         // Browser globals
         factory({}, root.echarts);
     }
-})(this, function(exports, echarts) {
+})(this || window, function(exports, echarts) {
     var log = function(msg) {
         if (typeof console !== 'undefined') {
             console && console.error && console.error(msg);

--- a/app/assets/javascripts/echarts/theme/jazz.js
+++ b/app/assets/javascripts/echarts/theme/jazz.js
@@ -31,7 +31,7 @@
         // Browser globals
         factory({}, root.echarts);
     }
-})(this, function(exports, echarts) {
+})(this || window, function(exports, echarts) {
     var log = function(msg) {
         if (typeof console !== 'undefined') {
             console && console.error && console.error(msg);

--- a/app/assets/javascripts/echarts/theme/london.js
+++ b/app/assets/javascripts/echarts/theme/london.js
@@ -31,7 +31,7 @@
         // Browser globals
         factory({}, root.echarts);
     }
-})(this, function(exports, echarts) {
+})(this || window, function(exports, echarts) {
     var log = function(msg) {
         if (typeof console !== 'undefined') {
             console && console.error && console.error(msg);

--- a/app/assets/javascripts/echarts/theme/macarons.js
+++ b/app/assets/javascripts/echarts/theme/macarons.js
@@ -31,7 +31,7 @@
         // Browser globals
         factory({}, root.echarts);
     }
-})(this, function(exports, echarts) {
+})(this || window, function(exports, echarts) {
     var log = function(msg) {
         if (typeof console !== 'undefined') {
             console && console.error && console.error(msg);

--- a/app/assets/javascripts/echarts/theme/macarons2.js
+++ b/app/assets/javascripts/echarts/theme/macarons2.js
@@ -31,7 +31,7 @@
         // Browser globals
         factory({}, root.echarts);
     }
-})(this, function(exports, echarts) {
+})(this || window, function(exports, echarts) {
     var log = function(msg) {
         if (typeof console !== 'undefined') {
             console && console.error && console.error(msg);

--- a/app/assets/javascripts/echarts/theme/mint.js
+++ b/app/assets/javascripts/echarts/theme/mint.js
@@ -31,7 +31,7 @@
         // Browser globals
         factory({}, root.echarts);
     }
-})(this, function(exports, echarts) {
+})(this || window, function(exports, echarts) {
     var log = function(msg) {
         if (typeof console !== 'undefined') {
             console && console.error && console.error(msg);

--- a/app/assets/javascripts/echarts/theme/rainbow.js
+++ b/app/assets/javascripts/echarts/theme/rainbow.js
@@ -32,7 +32,7 @@
         // Browser globals
         factory({}, root.echarts);
     }
-})(this, function(exports, echarts) {
+})(this || window, function(exports, echarts) {
     var log = function(msg) {
         if (typeof console !== 'undefined') {
             console && console.error && console.error(msg);

--- a/app/assets/javascripts/echarts/theme/red-velvet.js
+++ b/app/assets/javascripts/echarts/theme/red-velvet.js
@@ -31,7 +31,7 @@
         // Browser globals
         factory({}, root.echarts);
     }
-})(this, function(exports, echarts) {
+})(this || window, function(exports, echarts) {
     var log = function(msg) {
         if (typeof console !== 'undefined') {
             console && console.error && console.error(msg);

--- a/app/assets/javascripts/echarts/theme/red.js
+++ b/app/assets/javascripts/echarts/theme/red.js
@@ -31,7 +31,7 @@
         // Browser globals
         factory({}, root.echarts);
     }
-})(this, function(exports, echarts) {
+})(this || window, function(exports, echarts) {
     var log = function(msg) {
         if (typeof console !== 'undefined') {
             console && console.error && console.error(msg);

--- a/app/assets/javascripts/echarts/theme/roma.js
+++ b/app/assets/javascripts/echarts/theme/roma.js
@@ -32,7 +32,7 @@
         // Browser globals
         factory({}, root.echarts);
     }
-})(this, function(exports, echarts) {
+})(this || window, function(exports, echarts) {
     var log = function(msg) {
         if (typeof console !== 'undefined') {
             console && console.error && console.error(msg);

--- a/app/assets/javascripts/echarts/theme/royal.js
+++ b/app/assets/javascripts/echarts/theme/royal.js
@@ -31,7 +31,7 @@
         // Browser globals
         factory({}, root.echarts);
     }
-})(this, function(exports, echarts) {
+})(this || window, function(exports, echarts) {
     var log = function(msg) {
         if (typeof console !== 'undefined') {
             console && console.error && console.error(msg);

--- a/app/assets/javascripts/echarts/theme/sakura.js
+++ b/app/assets/javascripts/echarts/theme/sakura.js
@@ -31,7 +31,7 @@
         // Browser globals
         factory({}, root.echarts);
     }
-})(this, function(exports, echarts) {
+})(this || window, function(exports, echarts) {
     var log = function(msg) {
         if (typeof console !== 'undefined') {
             console && console.error && console.error(msg);

--- a/app/assets/javascripts/echarts/theme/shine.js
+++ b/app/assets/javascripts/echarts/theme/shine.js
@@ -30,7 +30,7 @@
         // Browser globals
         factory({}, root.echarts);
     }
-})(this, function(exports, echarts) {
+})(this || window, function(exports, echarts) {
     var log = function(msg) {
         if (typeof console !== 'undefined') {
             console && console.error && console.error(msg);

--- a/app/assets/javascripts/echarts/theme/tech-blue.js
+++ b/app/assets/javascripts/echarts/theme/tech-blue.js
@@ -31,7 +31,7 @@
         // Browser globals
         factory({}, root.echarts);
     }
-})(this, function(exports, echarts) {
+})(this || window, function(exports, echarts) {
     var log = function(msg) {
         if (typeof console !== 'undefined') {
             console && console.error && console.error(msg);

--- a/app/assets/javascripts/echarts/theme/v5.js
+++ b/app/assets/javascripts/echarts/theme/v5.js
@@ -31,7 +31,7 @@
         // Browser globals
         factory({}, root.echarts);
     }
-})(this, function(exports, echarts) {
+})(this || window, function(exports, echarts) {
     var log = function(msg) {
         if (typeof console !== 'undefined') {
             console && console.error && console.error(msg);

--- a/app/assets/javascripts/echarts/theme/vintage.js
+++ b/app/assets/javascripts/echarts/theme/vintage.js
@@ -31,7 +31,7 @@
         // Browser globals
         factory({}, root.echarts);
     }
-})(this, function(exports, echarts) {
+})(this || window, function(exports, echarts) {
     var log = function(msg) {
         if (typeof console !== 'undefined') {
             console && console.error && console.error(msg);


### PR DESCRIPTION
In the theme files `this` is passed as root or perhaps the global that might hold the echarts object. However in browser this is undefined and we are actually looking for `window`. This PR adds a fallback but it does not make the change within the actual function to define consumers `this`